### PR TITLE
feat: add CardNumber element and card brand events

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
@@ -25,6 +25,7 @@ internal protocol ElementReferenceProtocol {
 
 public enum ElementConfigError: Error {
     case invalidMask
+    case configNotAllowed
 }
 
 public class ElementValueReference: ElementReferenceProtocol {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateElementUITextField.swift
@@ -17,7 +17,7 @@ final public class CardExpirationDateUITextField: TextElementUITextField {
     
     private func validateExpirationDate(text: String?) -> Bool {
         guard text != nil else {
-            return true
+            return false
         }
         
         // check date is MM/YY -> 5 chars.
@@ -29,13 +29,7 @@ final public class CardExpirationDateUITextField: TextElementUITextField {
     }
     
     public override func setConfig(options: TextElementOptions?) throws {
-        if (options?.mask != nil) {
-            throw ElementConfigError.configNotAllowed
-        } else if (options?.transform != nil) {
-            throw ElementConfigError.configNotAllowed
-        }
-        
-        try super.setConfig(options: options)
+        throw ElementConfigError.configNotAllowed
     }
     
     private func validateFutureDate(text: String) -> Bool {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateElementUITextField.swift
@@ -28,6 +28,16 @@ final public class CardExpirationDateUITextField: TextElementUITextField {
         return validateFutureDate(text: text!)
     }
     
+    public override func setConfig(options: TextElementOptions?) throws {
+        if (options?.mask != nil) {
+            throw ElementConfigError.configNotAllowed
+        } else if (options?.transform != nil) {
+            throw ElementConfigError.configNotAllowed
+        }
+        
+        try super.setConfig(options: options)
+    }
+    
     private func validateFutureDate(text: String) -> Bool {
         let inputDateArray = super.getValue()?.components(separatedBy: "/")
         let inputMonth = Int(String(inputDateArray![0]))!

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
@@ -88,7 +88,7 @@ final public class CardNumberUITextField: TextElementUITextField {
         guard text != nil else {
             return true
         }
-
+        
         return validateLuhn(cardNumber: text)
     }
     
@@ -96,7 +96,7 @@ final public class CardNumberUITextField: TextElementUITextField {
         guard cardNumber != "" else {
             return false
         }
-
+        
         var sum = 0
         let digitStrings = cardNumber?.reversed().map { String($0) }
         

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
@@ -39,13 +39,7 @@ final public class CardNumberUITextField: TextElementUITextField {
     }
     
     public override func setConfig(options: TextElementOptions?) throws {
-        if (options?.mask != nil) {
-            throw ElementConfigError.configNotAllowed
-        } else if (options?.transform != nil) {
-            throw ElementConfigError.configNotAllowed
-        }
-        
-        try super.setConfig(options: options)
+        throw ElementConfigError.configNotAllowed
     }
     
     private func getDefaultCardMask() -> [Any] {
@@ -86,7 +80,7 @@ final public class CardNumberUITextField: TextElementUITextField {
     
     private func validateCardNumber(text: String?) -> Bool {
         guard text != nil else {
-            return true
+            return false
         }
         
         return validateLuhn(cardNumber: text)

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
@@ -1,0 +1,137 @@
+//
+//  CardNumberElementUITextField.swift
+//  
+//
+//  Created by Lucas Chociay on 01/12/22.
+//
+
+import UIKit
+
+final public class CardNumberUITextField: TextElementUITextField {
+    private var cardBrand: CardBrandResults?
+    
+    override var getElementEvent: ((String?, ElementEvent) -> ElementEvent)? {
+        get {
+            getCardElementEvent
+            
+        }
+        set { }
+    }
+    
+    override var validation: ((String?) -> Bool)? {
+        get {
+            validateCardNumber
+        }
+        set { }
+    }
+    
+    private func getCardElementEvent(text: String?, event: ElementEvent) -> ElementEvent {
+        let complete = cardBrand?.complete ?? false
+        let valid = self.validation?(text) ?? false
+        let brand = cardBrand?.bestMatchCardBrand?.cardBrandName != nil ? String(describing: cardBrand!.bestMatchCardBrand!.cardBrandName) : "unknown"
+        let brandDetail = ElementEventDetails(type: "cardBrand", message: brand)
+        
+        let elementEvent = ElementEvent(type: "textChange", complete: complete, empty: text?.isEmpty ?? true, valid: valid, details: [brandDetail
+        ])
+        
+        return elementEvent
+    }
+    
+    private func validateCardNumber(text: String?) -> Bool {
+        guard text != nil else {
+            return true
+        }
+        
+        return validateLuhn(cardNumber: text!)
+    }
+    
+    private func validateLuhn(cardNumber: String) -> Bool {
+        var sum = 0
+        let digitStrings = cardNumber.reversed().map { String($0) }
+
+        for tuple in digitStrings.enumerated() {
+            if let digit = Int(tuple.element) {
+                let odd = tuple.offset % 2 == 1
+
+                switch (odd, digit) {
+                case (true, 9):
+                    sum += 9
+                case (true, 0...8):
+                    sum += (digit * 2) % 9
+                default:
+                    sum += digit
+                }
+            } else {
+                return false
+            }
+        }
+        return sum % 10 == 0
+    }
+    
+    private func updateCardMask(mask: [Any]?) {
+        self.inputMask = mask
+    }
+    
+    override var inputMask: [Any]? {
+        get {
+            let digitRegex = try! NSRegularExpression(pattern: "\\d")
+            // TODO: modify dynamically according to card brand
+            return [
+                digitRegex,
+                digitRegex,
+                digitRegex,
+                digitRegex,
+                " ",
+                digitRegex,
+                digitRegex,
+                digitRegex,
+                digitRegex,
+                " ",
+                digitRegex,
+                digitRegex,
+                digitRegex,
+                digitRegex,
+                " ",
+                digitRegex,
+                digitRegex,
+                digitRegex,
+                digitRegex
+            ]
+        }
+        set { }
+    }
+    
+    override var inputTransform: ElementTransform? {
+        get {
+            let spaceRegex = try! NSRegularExpression(pattern: "[ \t]")
+            return ElementTransform(matcher: spaceRegex)
+        }
+        set { }
+    }
+    
+    override func textFieldDidChange() {
+        // run event to conform to mask
+        super.textFieldDidChange()
+        
+        if (super.getValue() != nil) {
+            cardBrand = CardBrand.getCardBrand(text: super.getValue())
+            
+            if (cardBrand?.bestMatchCardBrand != nil) {
+                updateCardMask(mask: cardBrand?.bestMatchCardBrand?.cardNumberMaskInput)
+            }
+        }
+        
+        super.textFieldDidChange()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.keyboardType = .asciiCapableNumberPad
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.keyboardType = .asciiCapableNumberPad
+    }
+}

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardVerificationCodeElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardVerificationCodeElementUITextField.swift
@@ -23,6 +23,16 @@ final public class CardVerificationCodeElementUITextField: TextElementUITextFiel
         return text!.range(of: "^[0-9]{3,4}$", options: .regularExpression) != nil
     }
     
+    public override func setConfig(options: TextElementOptions?) throws {
+        if (options?.mask != nil) {
+            throw ElementConfigError.configNotAllowed
+        } else if (options?.transform != nil) {
+            throw ElementConfigError.configNotAllowed
+        }
+        
+        try super.setConfig(options: options)
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.keyboardType = .asciiCapableNumberPad

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardVerificationCodeElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardVerificationCodeElementUITextField.swift
@@ -17,20 +17,14 @@ final public class CardVerificationCodeElementUITextField: TextElementUITextFiel
     
     private func validateCvc(text: String?) -> Bool {
         guard text != nil else {
-            return true
+            return false
         }
         
         return text!.range(of: "^[0-9]{3,4}$", options: .regularExpression) != nil
     }
     
     public override func setConfig(options: TextElementOptions?) throws {
-        if (options?.mask != nil) {
-            throw ElementConfigError.configNotAllowed
-        } else if (options?.transform != nil) {
-            throw ElementConfigError.configNotAllowed
-        }
-        
-        try super.setConfig(options: options)
+        throw ElementConfigError.configNotAllowed
     }
     
     override init(frame: CGRect) {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
@@ -25,7 +25,7 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
     var backspacePressed: Bool = false
     var inputMask: [Any]?
     var inputTransform: ElementTransform?
-    var previousValue: String = "abc"
+    var previousValue: String = ""
     
     public var subject = PassthroughSubject<ElementEvent, Error>()
     
@@ -177,6 +177,7 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
             elementEvent = getElementEvent(transformedTextValue, elementEvent)
         }
         
+        // prevents sending an additional event if input didn't change
         if (previousValue == super.text) {
             return
         } else {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
@@ -25,6 +25,7 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
     var backspacePressed: Bool = false
     var inputMask: [Any]?
     var inputTransform: ElementTransform?
+    var previousValue: String = "abc"
     
     public var subject = PassthroughSubject<ElementEvent, Error>()
     
@@ -149,37 +150,37 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
         var maskComplete = true
         
         if inputMask != nil {
-            let previousValue = super.text
-            
             // dont conform on backspace pressed - just remove the value + check for backspace on empty
             if (!backspacePressed || super.text != nil) {
                 super.text = conformToMask(text: super.text)
             } else {
                 backspacePressed = false
             }
-            
+
             if (super.text?.count != inputMask!.count ) {
                 maskComplete = false
             }
-            
-            guard previousValue == super.text else {
-                return
-            }
         }
         
-        let currentTextValue = super.text
+        let transformedTextValue = self.transform(text: super.text)
         var valid = true
 
         if let validation = validation {
-            valid = validation(currentTextValue)
+            valid = validation(transformedTextValue)
         }
         
         let complete = valid && maskComplete
         
-        var elementEvent = ElementEvent(type: "textChange", complete: complete, empty: currentTextValue?.isEmpty ?? true, valid: valid, details: [])
+        var elementEvent = ElementEvent(type: "textChange", complete: complete, empty: transformedTextValue.isEmpty , valid: valid, details: [])
         
         if let getElementEvent = getElementEvent {
-            elementEvent = getElementEvent(currentTextValue, elementEvent)
+            elementEvent = getElementEvent(transformedTextValue, elementEvent)
+        }
+        
+        if (previousValue == super.text) {
+            return
+        } else {
+            previousValue = super.text!
         }
         
         subject.send(elementEvent)

--- a/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
+++ b/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		428CB1062937C53000C8220E /* CardExpirationDateUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428CB1052937C53000C8220E /* CardExpirationDateUITextFieldTests.swift */; };
+		428CB10A293E398B00C8220E /* CardNumberUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428CB109293E398B00C8220E /* CardNumberUITextFieldTests.swift */; };
 		9206601D2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9206601C2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift */; };
 		9245768928FF46C100A01E70 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245768828FF46C100A01E70 /* AppDelegate.swift */; };
 		9245768B28FF46C100A01E70 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245768A28FF46C100A01E70 /* SceneDelegate.swift */; };
@@ -49,6 +50,7 @@
 
 /* Begin PBXFileReference section */
 		428CB1052937C53000C8220E /* CardExpirationDateUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardExpirationDateUITextFieldTests.swift; sourceTree = "<group>"; };
+		428CB109293E398B00C8220E /* CardNumberUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberUITextFieldTests.swift; sourceTree = "<group>"; };
 		9206601C2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardVerificationCodeUITextFieldTests.swift; sourceTree = "<group>"; };
 		9245768528FF46C100A01E70 /* IntegrationTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntegrationTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9245768828FF46C100A01E70 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				9245769F28FF46C200A01E70 /* TextElementUITextFieldTests.swift */,
 				428CB1052937C53000C8220E /* CardExpirationDateUITextFieldTests.swift */,
 				92B7DCAE2939523C000DBB8A /* CardBrandTests.swift */,
+				428CB109293E398B00C8220E /* CardNumberUITextFieldTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				428CB10A293E398B00C8220E /* CardNumberUITextFieldTests.swift in Sources */,
 				928869A72911B564004E75E3 /* Configuration.swift in Sources */,
 				92B7DCAF2939523C000DBB8A /* CardBrandTests.swift in Sources */,
 				428CB1062937C53000C8220E /* CardExpirationDateUITextFieldTests.swift in Sources */,

--- a/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
+++ b/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
@@ -116,19 +116,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vqA-gB-ZZB" customClass="CardVerificationCodeElementUITextField" customModule="BasisTheoryElements">
-                                <rect key="frame" x="147" y="97" width="96" height="34"/>
+                                <rect key="frame" x="41" y="130" width="309" height="34"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9OB-9S-4ob" customClass="CardExpirationDateUITextField" customModule="BasisTheoryElements">
-                                <rect key="frame" x="147" y="47" width="96" height="34"/>
+                                <rect key="frame" x="41" y="88" width="309" height="34"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mcT-S8-VFR">
-                                <rect key="frame" x="150" y="152" width="91" height="35"/>
+                                <rect key="frame" x="150" y="211" width="91" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Tokenize"/>
@@ -137,7 +137,21 @@
                                 </connections>
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qKC-eP-oxh">
-                                <rect key="frame" x="41" y="195" width="309" height="544"/>
+                                <rect key="frame" x="41" y="305" width="309" height="544"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HIZ-Cg-Hjq" customClass="CardNumberUITextField" customModule="BasisTheoryElements">
+                                <rect key="frame" x="41" y="46" width="309" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="VhI-uu-QOW">
+                                <rect key="frame" x="75" y="177" width="240" height="33"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -150,6 +164,8 @@
                     </view>
                     <navigationItem key="navigationItem" id="G1W-R6-TzL"/>
                     <connections>
+                        <outlet property="cardBrand" destination="VhI-uu-QOW" id="Z2m-Gi-bBx"/>
+                        <outlet property="cardNumberTextField" destination="HIZ-Cg-Hjq" id="Jx3-Yf-YYB"/>
                         <outlet property="cvcTextField" destination="vqA-gB-ZZB" id="q6X-4X-aam"/>
                         <outlet property="expirationDateTextField" destination="9OB-9S-4ob" id="oqo-vA-Zar"/>
                         <outlet property="output" destination="qKC-eP-oxh" id="fCS-lD-m61"/>

--- a/IntegrationTester/IntegrationTester/SplitCardElementsViewController.swift
+++ b/IntegrationTester/IntegrationTester/SplitCardElementsViewController.swift
@@ -15,14 +15,16 @@ class SplitCardElementsViewController: UIViewController {
     private let darkBackgroundColor : UIColor = UIColor( red: 200/255, green: 200/255, blue: 200/255, alpha: 1.0 )
     private var cancellables = Set<AnyCancellable>()
     
+    @IBOutlet weak var cardNumberTextField: CardNumberUITextField!
     @IBOutlet weak var expirationDateTextField: CardExpirationDateUITextField!
     @IBOutlet weak var cvcTextField: CardVerificationCodeElementUITextField!
     @IBOutlet weak var output: UITextView!
+    @IBOutlet weak var cardBrand: UITextView!
     
     @IBAction func tokenize(_ sender: Any) {
         let body: [String: Any] = [
             "data": [
-                "number": "4242424242424242",
+                "number": self.cardNumberTextField,
                 "expiration_month": self.expirationDateTextField.month(),
                 "expiration_year": self.expirationDateTextField.year(),
                 "cvc": self.cvcTextField
@@ -50,12 +52,34 @@ class SplitCardElementsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setStyles(textField: cardNumberTextField, placeholder: "Card Number")
         setStyles(textField: expirationDateTextField, placeholder: "MM/YY")
         setStyles(textField: cvcTextField, placeholder: "CVC")
+        
+        cardNumberTextField.subject.sink { completion in
+            print(completion)
+        } receiveValue: { message in
+            print("cardNumber:")
+            print(message)
+            
+            if (!message.details.isEmpty) {
+                var brandDetails = message.details[0]
+                
+                self.cardBrand.text = brandDetails.type + ": " + brandDetails.message
+            }
+        }.store(in: &cancellables)
+        
+        expirationDateTextField.subject.sink { completion in
+            print(completion)
+        } receiveValue: { message in
+            print("expirationDate:")
+            print(message)
+        }.store(in: &cancellables)
         
         cvcTextField.subject.sink { completion in
             print(completion)
         } receiveValue: { message in
+            print("CVC:")
             print(message)
         }.store(in: &cancellables)
     }

--- a/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
@@ -97,8 +97,8 @@ final class CardNumberUITextFieldTests: XCTestCase {
     func testWithAndWithoutCardNumberInputEvents() throws {
         let cardNumberTextField = CardNumberUITextField()
         
-        let numberInputExpectation = self.expectation(description: "Expiration date input")
-        let numberDeleteExpectation = self.expectation(description: "Expiration date delete")
+        let numberInputExpectation = self.expectation(description: "Card number input")
+        let numberDeleteExpectation = self.expectation(description: "Card number delete")
         var cancellables = Set<AnyCancellable>()
         cardNumberTextField.subject.sink { completion in
             print(completion)

--- a/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
@@ -1,0 +1,125 @@
+//
+//  CardNumberUITextFieldTests.swift
+//  IntegrationTesterTests
+//
+//  Created by Lucas Chociay on 12/05/22.
+//
+
+import XCTest
+import BasisTheoryElements
+import BasisTheory
+import Combine
+
+final class CardNumberUITextFieldTests: XCTestCase {
+    override func setUpWithError() throws { }
+    override func tearDownWithError() throws { }
+    
+    func testInvalidCardNumberEvents() throws {
+        let cardNumberTextField = CardNumberUITextField()
+        
+        let incompleteNumberExpectation = self.expectation(description: "Incomplete card number")
+        let luhnInvalidNumberExpectation = self.expectation(description: "Luhn invalid card")
+        
+        var incompleteNumberExpectationHasBeenFulfilled = false
+        
+        var cancellables = Set<AnyCancellable>()
+        cardNumberTextField.subject.sink { completion in
+            print(completion)
+        } receiveValue: { message in
+            XCTAssertEqual(message.type, "textChange")
+            XCTAssertEqual(message.empty, false)
+            XCTAssertEqual(message.valid, false)
+            
+            if (!incompleteNumberExpectationHasBeenFulfilled) {
+                XCTAssertEqual(message.complete, false)
+                incompleteNumberExpectation.fulfill()
+                incompleteNumberExpectationHasBeenFulfilled = true
+            } else {
+                XCTAssertEqual(message.complete, true) // mask completed but number invalid
+                luhnInvalidNumberExpectation.fulfill()
+            }
+        }.store(in: &cancellables)
+        
+        cardNumberTextField.insertText("4129")
+        cardNumberTextField.text = ""
+        cardNumberTextField.insertText("4129939187355598") // luhn invalid
+        cardNumberTextField.text = ""
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testValidNumberAndBrandEvents() throws {
+        let cardNumberTextField = CardNumberUITextField()
+        
+        let validVisaCardNumberExpectation = self.expectation(description: "Valid visa card number")
+        let validMasterCardNumberExpectation = self.expectation(description: "Valid mastercard card number")
+        let validAmexCardNumberExpectation = self.expectation(description: "Valid amex card number")
+        
+        var visaExpectationHasBeenFulfilled = false
+        var mastercardExpectationHasBeenFulfilled = false
+        
+        var cancellables = Set<AnyCancellable>()
+        cardNumberTextField.subject.sink { completion in
+            print(completion)
+        } receiveValue: { message in
+            XCTAssertEqual(message.type, "textChange")
+            XCTAssertEqual(message.empty, false)
+            XCTAssertEqual(message.valid, true)
+            let brandDetails = message.details[0] as ElementEventDetails
+            XCTAssertEqual(brandDetails.type, "cardBrand")
+            
+            if (!visaExpectationHasBeenFulfilled) {
+                XCTAssertEqual(message.complete, true)
+                XCTAssertEqual(brandDetails.message, "visa")
+                validVisaCardNumberExpectation.fulfill()
+                visaExpectationHasBeenFulfilled = true
+            } else if (!mastercardExpectationHasBeenFulfilled) {
+                XCTAssertEqual(message.complete, true)
+                XCTAssertEqual(brandDetails.message, "mastercard")
+                validMasterCardNumberExpectation.fulfill()
+                mastercardExpectationHasBeenFulfilled = true
+            } else {
+                XCTAssertEqual(message.complete, true)
+                XCTAssertEqual(brandDetails.message, "americanExpress")
+                validAmexCardNumberExpectation.fulfill()
+            }
+        }.store(in: &cancellables)
+        
+        cardNumberTextField.insertText("4242424242424242")
+        cardNumberTextField.text = ""
+        cardNumberTextField.insertText("5454422955385717")
+        cardNumberTextField.text = ""
+        cardNumberTextField.insertText("348570250878868")
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testWithAndWithoutCardNumberInputEvents() throws {
+        let cardNumberTextField = CardNumberUITextField()
+        
+        let numberInputExpectation = self.expectation(description: "Expiration date input")
+        let numberDeleteExpectation = self.expectation(description: "Expiration date delete")
+        var cancellables = Set<AnyCancellable>()
+        cardNumberTextField.subject.sink { completion in
+            print(completion)
+        } receiveValue: { message in
+            XCTAssertEqual(message.type, "textChange")
+            
+            if (!message.empty) {
+                XCTAssertEqual(message.valid, true)
+                XCTAssertEqual(message.complete, true)
+                numberInputExpectation.fulfill()
+            } else {
+                XCTAssertEqual(message.valid, false)
+                XCTAssertEqual(message.complete, false)
+                numberDeleteExpectation.fulfill()
+            }
+        }.store(in: &cancellables)
+        
+        cardNumberTextField.insertText("4242424242424242")
+        cardNumberTextField.text = ""
+        cardNumberTextField.insertText("")
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/IntegrationTester/UnitTests/ElementUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/ElementUITextFieldTests.swift
@@ -21,6 +21,7 @@ class ElementUITextFieldTests: XCTestCase {
         let testSuite = XCTestSuite(name: NSStringFromClass(self))
 
         addTestsWithElement(element: TextElementUITextField(), elementInput: "Drewsue Webuino", toTestSuite: testSuite)
+        addTestsWithElement(element: CardNumberUITextField(), elementInput: "4242424242424242", toTestSuite: testSuite)
         addTestsWithElement(element: CardExpirationDateUITextField(), elementInput: "12/99", toTestSuite: testSuite)
         addTestsWithElement(element: CardVerificationCodeElementUITextField(), elementInput: "123", toTestSuite: testSuite)
         


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds new `CardNumberTextField` element
- Adds `cardBrand` events to `CardNumberTextField`
- Fixes issue where you could do `setConfig` from card elements
- Improve validation to use transformed value instead of masked.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
