### PR TITLE
eng-3935: UI testing on elements with dynamic masks

### DIFF
--- a/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
+++ b/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
@@ -1,11 +1,15 @@
 //
-//  SplitCardElementsUITextFieldTests.swift
+//  SplitCardElementsIntegrationTesterUITests.swift
 //  AcceptanceTests
 //
 //  Created by Amber Torres on 12/20/22.
 //
 
+import Foundation
+
 import XCTest
+import BasisTheoryElements
+import Combine
 
 final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
     private var app: XCUIApplication = XCUIApplication()
@@ -20,26 +24,120 @@ final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
     override func tearDownWithError() throws { }
     
     func testTextSetter() throws {
-        //TO-DO
+        let setTextButton = app.buttons["Set Text"]
+        setTextButton.press(forDuration: 0.1)
+        
+        let cardNumberTextField = app.textFields["Card Number"]
+        let expirationDateTextField = app.textFields["MM/YY"]
+        let cvcTextField = app.textFields["CVC"]
+        
+        XCTAssertEqual(cardNumberTextField.value as! String, "4242 4242 4242 4242")
+        XCTAssertEqual(expirationDateTextField.value as! String, "10/26")
+        XCTAssertEqual(cvcTextField.value as! String, "909")
     }
     
-    func testCardNumberMaskIsAppropriateForCardBrand() throws {
+    
+    func testCardNumberMaskForVisaAndMastercard() throws {
         let validVisaCardNumber = "4242424242424242"
-        let invalidVisaCardNumbers = ["424242424242424a"
+        let invalidVisaCardNumber = "42424242424242aa"
+        
+        let validMastercardCardNumber = "5151515151515151"
+        let invalidMastercardCardNumber = "51515151515151aa"
+        
+        let validCVC = "123"
+        let invalidCVC = "1234"
         
         let cardNumberTextField = app.textFields["Card Number"]
         cardNumberTextField.tap()
         
-        cardNumberTextField.typeText(visaCardNumber)
+        cardNumberTextField.typeText(validVisaCardNumber)
         XCTAssertEqual(cardNumberTextField.value as! String, "4242 4242 4242 4242")
         
-        cardNumberTextField.doubleTap()
-        app.keys["delete"].tap()
+        let visaCardBrandResults = CardBrand.getCardBrand(text: validVisaCardNumber)
+        XCTAssertEqual(visaCardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.visa)
         
+        cardNumberTextField.doubleTap()
+        
+        cardNumberTextField.typeText(invalidVisaCardNumber)
+        XCTAssertEqual(cardNumberTextField.value as! String, "4242 4242 4242 42")
+        
+        let invalidVisaCardBrandResults = CardBrand.getCardBrand(text: invalidVisaCardNumber)
+        XCTAssertEqual(invalidVisaCardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.visa)
+        
+        try testCVC()
+        
+        // Change the card brand from visa mastercard to ensure brand change is detected and the mask updates
+        
+        cardNumberTextField.doubleTap()
+
+        cardNumberTextField.typeText(validMastercardCardNumber)
+        XCTAssertEqual(cardNumberTextField.value as! String, "5151 5151 5151 5151")
+
+        let mastercardCardBrandResults = CardBrand.getCardBrand(text: validMastercardCardNumber)
+        XCTAssertEqual(mastercardCardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.mastercard)
+        
+        cardNumberTextField.doubleTap()
+        
+        cardNumberTextField.typeText(invalidMastercardCardNumber)
+        XCTAssertEqual(cardNumberTextField.value as! String, "5151 5151 5151 51")
+        
+        let invalidMasterCardBrandResults = CardBrand.getCardBrand(text: invalidMastercardCardNumber)
+        XCTAssertEqual(invalidMasterCardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.mastercard)
+        
+        try testCVC()
+        
+        func testCVC() throws {
+            
+            let cvcTextField = app.textFields["CVC"]
+            cvcTextField.tap()
+            
+            cvcTextField.typeText(validCVC)
+            XCTAssertEqual(cvcTextField.value as! String, "123")
+            
+            cvcTextField.doubleTap()
+            
+            cvcTextField.typeText(invalidCVC)
+            XCTAssertEqual(cvcTextField.value as! String, "123")
+        }
+        
+        // To-do: Investigate how to make more concise
         
     }
     
-    func testCVCIsAppropriateForCardBrand() throws {
-        //TODO
+    func testCardNumberAndCVCMaskForAmericanExpress() throws {
+        let validAmericanExpressCardNumber = "348570250878868"
+        let invalidAmericanExpressCardNumber = "34aa70250878868"
+        let validCVC = "1234"
+        let invalidCVC = "123"
+
+        let cardNumberTextField = app.textFields["Card Number"]
+        cardNumberTextField.tap()
+
+        cardNumberTextField.typeText(validAmericanExpressCardNumber)
+        XCTAssertEqual(cardNumberTextField.value as! String, "3485 702508 78868")
+        
+        let cardBrandResults = CardBrand.getCardBrand(text: validAmericanExpressCardNumber)
+        XCTAssertEqual(cardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.americanExpress)
+        
+        cardNumberTextField.doubleTap()
+
+        cardNumberTextField.typeText(invalidAmericanExpressCardNumber)
+        XCTAssertEqual(cardNumberTextField.value as! String, "3470 250878 868")
+        
+        let cvcTextField = app.textFields["CVC"]
+        cvcTextField.tap()
+        
+        cvcTextField.typeText(validCVC)
+        XCTAssertEqual(cvcTextField.value as! String, "1234")
+        
+        cvcTextField.doubleTap()
+        
+        cvcTextField.typeText(invalidCVC)
+        XCTAssertEqual(cvcTextField.value as! String, "123")
+        
     }
+
+    //to-do: diners club, 
+
+    //to-do: discover, jcb, union pay, maestro, elo, mir, hiper, hipercard are same as visa and mastercard in terms of cvc length and gaps
 }

--- a/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
+++ b/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
@@ -1,0 +1,45 @@
+//
+//  SplitCardElementsUITextFieldTests.swift
+//  AcceptanceTests
+//
+//  Created by Amber Torres on 12/20/22.
+//
+
+import XCTest
+
+final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
+    private var app: XCUIApplication = XCUIApplication()
+
+    override func setUpWithError() throws {
+        app.launch()
+        
+        let textElementExampleButton = app.buttons["Split Card Elements Example"]
+        textElementExampleButton.press(forDuration: 0.1)
+    }
+    
+    override func tearDownWithError() throws { }
+    
+    func testTextSetter() throws {
+        //TO-DO
+    }
+    
+    func testCardNumberMaskIsAppropriateForCardBrand() throws {
+        let validVisaCardNumber = "4242424242424242"
+        let invalidVisaCardNumbers = ["424242424242424a"
+        
+        let cardNumberTextField = app.textFields["Card Number"]
+        cardNumberTextField.tap()
+        
+        cardNumberTextField.typeText(visaCardNumber)
+        XCTAssertEqual(cardNumberTextField.value as! String, "4242 4242 4242 4242")
+        
+        cardNumberTextField.doubleTap()
+        app.keys["delete"].tap()
+        
+        
+    }
+    
+    func testCVCIsAppropriateForCardBrand() throws {
+        //TODO
+    }
+}

--- a/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
+++ b/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
@@ -34,7 +34,6 @@ final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
         XCTAssertEqual(cardNumberTextField.value as! String, "4242 4242 4242 4242")
         XCTAssertEqual(expirationDateTextField.value as! String, "10/26")
         XCTAssertEqual(cvcTextField.value as! String, "909")
-        // To-do: how to get the card brand to be detected here?
     }
     
     

--- a/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
+++ b/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
@@ -13,7 +13,7 @@ import Combine
 
 final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
     private var app: XCUIApplication = XCUIApplication()
-
+    
     override func setUpWithError() throws {
         app.launch()
         
@@ -34,18 +34,22 @@ final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
         XCTAssertEqual(cardNumberTextField.value as! String, "4242 4242 4242 4242")
         XCTAssertEqual(expirationDateTextField.value as! String, "10/26")
         XCTAssertEqual(cvcTextField.value as! String, "909")
+        // To-do: how to get the card brand to be detected here?
     }
     
     
-    func testCardNumberMaskForVisaAndMastercard() throws {
+    func testCardNumberMaskForVisaToAmericanExpress() throws {
         let validVisaCardNumber = "4242424242424242"
-        let invalidVisaCardNumber = "42424242424242aa"
+        let invalidVisaCardNumber = "42424242424242xx"
         
-        let validMastercardCardNumber = "5151515151515151"
-        let invalidMastercardCardNumber = "51515151515151aa"
+        let validAmericanExpressCardNumber = "348570250878868"
+        let invalidAmericanExpressCardNumber = "34xx70250878868"
         
-        let validCVC = "123"
-        let invalidCVC = "1234"
+        let visaValidCVC = "432"
+        let visaInvalidCVC = "4321"
+        
+        let americanExpressValidCVC = "1234"
+        let americanExpressInvalidCVC = "12345"
         
         let cardNumberTextField = app.textFields["Card Number"]
         cardNumberTextField.tap()
@@ -64,55 +68,12 @@ final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
         let invalidVisaCardBrandResults = CardBrand.getCardBrand(text: invalidVisaCardNumber)
         XCTAssertEqual(invalidVisaCardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.visa)
         
-        try testCVC()
+        try testVisaCVC()
         
-        // Change the card brand from visa mastercard to ensure brand change is detected and the mask updates
-        
-        cardNumberTextField.doubleTap()
-
-        cardNumberTextField.typeText(validMastercardCardNumber)
-        XCTAssertEqual(cardNumberTextField.value as! String, "5151 5151 5151 5151")
-
-        let mastercardCardBrandResults = CardBrand.getCardBrand(text: validMastercardCardNumber)
-        XCTAssertEqual(mastercardCardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.mastercard)
+        // Change the card from visa to amex to ensure brand change is detected and the mask updates accordingly
         
         cardNumberTextField.doubleTap()
         
-        cardNumberTextField.typeText(invalidMastercardCardNumber)
-        XCTAssertEqual(cardNumberTextField.value as! String, "5151 5151 5151 51")
-        
-        let invalidMasterCardBrandResults = CardBrand.getCardBrand(text: invalidMastercardCardNumber)
-        XCTAssertEqual(invalidMasterCardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.mastercard)
-        
-        try testCVC()
-        
-        func testCVC() throws {
-            
-            let cvcTextField = app.textFields["CVC"]
-            cvcTextField.tap()
-            
-            cvcTextField.typeText(validCVC)
-            XCTAssertEqual(cvcTextField.value as! String, "123")
-            
-            cvcTextField.doubleTap()
-            
-            cvcTextField.typeText(invalidCVC)
-            XCTAssertEqual(cvcTextField.value as! String, "123")
-        }
-        
-        // To-do: Investigate how to make more concise
-        
-    }
-    
-    func testCardNumberAndCVCMaskForAmericanExpress() throws {
-        let validAmericanExpressCardNumber = "348570250878868"
-        let invalidAmericanExpressCardNumber = "34aa70250878868"
-        let validCVC = "1234"
-        let invalidCVC = "123"
-
-        let cardNumberTextField = app.textFields["Card Number"]
-        cardNumberTextField.tap()
-
         cardNumberTextField.typeText(validAmericanExpressCardNumber)
         XCTAssertEqual(cardNumberTextField.value as! String, "3485 702508 78868")
         
@@ -120,24 +81,38 @@ final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
         XCTAssertEqual(cardBrandResults.bestMatchCardBrand!.cardBrandName, CardBrand.CardBrandName.americanExpress)
         
         cardNumberTextField.doubleTap()
-
+        
         cardNumberTextField.typeText(invalidAmericanExpressCardNumber)
         XCTAssertEqual(cardNumberTextField.value as! String, "3470 250878 868")
         
-        let cvcTextField = app.textFields["CVC"]
-        cvcTextField.tap()
+        try testAmericanExpressCVC()
         
-        cvcTextField.typeText(validCVC)
-        XCTAssertEqual(cvcTextField.value as! String, "1234")
+        func testVisaCVC() throws {
+            
+            let cvcTextField = app.textFields["CVC"]
+            cvcTextField.tap()
+            
+            cvcTextField.typeText(visaValidCVC)
+            XCTAssertEqual(cvcTextField.value as! String, "432")
+            
+            cvcTextField.doubleTap()
+            
+            cvcTextField.typeText(visaInvalidCVC)
+            XCTAssertEqual(cvcTextField.value as! String, "432")
+        }
         
-        cvcTextField.doubleTap()
-        
-        cvcTextField.typeText(invalidCVC)
-        XCTAssertEqual(cvcTextField.value as! String, "123")
-        
+        func testAmericanExpressCVC() throws {
+            
+            let cvcTextField = app.textFields["CVC"]
+            cvcTextField.doubleTap()
+            
+            cvcTextField.typeText(americanExpressValidCVC)
+            XCTAssertEqual(cvcTextField.value as! String, "1234")
+            
+            cvcTextField.doubleTap()
+            
+            cvcTextField.typeText(americanExpressInvalidCVC)
+            XCTAssertEqual(cvcTextField.value as! String, "1234")
+        }
     }
-
-    //to-do: diners club, 
-
-    //to-do: discover, jcb, union pay, maestro, elo, mir, hiper, hipercard are same as visa and mastercard in terms of cvc length and gaps
 }

--- a/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
+++ b/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		428CB1062937C53000C8220E /* CardExpirationDateUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428CB1052937C53000C8220E /* CardExpirationDateUITextFieldTests.swift */; };
 		428CB10A293E398B00C8220E /* CardNumberUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428CB109293E398B00C8220E /* CardNumberUITextFieldTests.swift */; };
 		6286CEC129523C8200F7E8BD /* SplitCardElementsUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6286CEC029523C8200F7E8BD /* SplitCardElementsUITextFieldTests.swift */; };
+		62BEB1442953A1C600E5A0CE /* BasisTheoryElements in Frameworks */ = {isa = PBXBuildFile; productRef = 62BEB1432953A1C600E5A0CE /* BasisTheoryElements */; };
 		9206601D2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9206601C2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift */; };
 		9245768928FF46C100A01E70 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245768828FF46C100A01E70 /* AppDelegate.swift */; };
 		9245768B28FF46C100A01E70 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245768A28FF46C100A01E70 /* SceneDelegate.swift */; };
@@ -97,6 +98,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62BEB1442953A1C600E5A0CE /* BasisTheoryElements in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -231,6 +233,7 @@
 			);
 			name = AcceptanceTests;
 			packageProductDependencies = (
+				62BEB1432953A1C600E5A0CE /* BasisTheoryElements */,
 			);
 			productName = IntegrationTesterUITests;
 			productReference = 924576A528FF46C200A01E70 /* AcceptanceTests.xctest */;
@@ -686,6 +689,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		62BEB1432953A1C600E5A0CE /* BasisTheoryElements */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BasisTheoryElements;
+		};
 		92566EA5293578B30047BFF2 /* BasisTheoryElements */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BasisTheoryElements;

--- a/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
+++ b/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		428CB1062937C53000C8220E /* CardExpirationDateUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428CB1052937C53000C8220E /* CardExpirationDateUITextFieldTests.swift */; };
 		428CB10A293E398B00C8220E /* CardNumberUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428CB109293E398B00C8220E /* CardNumberUITextFieldTests.swift */; };
+		6286CEC129523C8200F7E8BD /* SplitCardElementsUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6286CEC029523C8200F7E8BD /* SplitCardElementsUITextFieldTests.swift */; };
 		9206601D2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9206601C2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift */; };
 		9245768928FF46C100A01E70 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245768828FF46C100A01E70 /* AppDelegate.swift */; };
 		9245768B28FF46C100A01E70 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245768A28FF46C100A01E70 /* SceneDelegate.swift */; };
@@ -52,6 +53,7 @@
 /* Begin PBXFileReference section */
 		428CB1052937C53000C8220E /* CardExpirationDateUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardExpirationDateUITextFieldTests.swift; sourceTree = "<group>"; };
 		428CB109293E398B00C8220E /* CardNumberUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberUITextFieldTests.swift; sourceTree = "<group>"; };
+		6286CEC029523C8200F7E8BD /* SplitCardElementsUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitCardElementsUITextFieldTests.swift; sourceTree = "<group>"; };
 		9206601C2922813C00A92A81 /* CardVerificationCodeUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardVerificationCodeUITextFieldTests.swift; sourceTree = "<group>"; };
 		9245768528FF46C100A01E70 /* IntegrationTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntegrationTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9245768828FF46C100A01E70 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 			isa = PBXGroup;
 			children = (
 				924576A928FF46C200A01E70 /* TextElementUITextFieldTests.swift */,
+				6286CEC029523C8200F7E8BD /* SplitCardElementsUITextFieldTests.swift */,
 			);
 			path = AcceptanceTests;
 			sourceTree = "<group>";
@@ -339,6 +342,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6286CEC129523C8200F7E8BD /* SplitCardElementsUITextFieldTests.swift in Sources */,
 				928869A229118DC4004E75E3 /* Configuration.swift in Sources */,
 				924576AA28FF46C200A01E70 /* TextElementUITextFieldTests.swift in Sources */,
 			);

--- a/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
+++ b/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
@@ -163,6 +163,9 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Set Text"/>
+                                <connections>
+                                    <action selector="printToConsoleLog:" destination="1yo-MQ-bQK" eventType="touchUpInside" id="83M-Z9-nEk"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="627-3o-X4v"/>

--- a/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
+++ b/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
@@ -128,7 +128,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mcT-S8-VFR">
-                                <rect key="frame" x="150" y="211" width="91" height="35"/>
+                                <rect key="frame" x="41" y="210" width="141" height="51"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="filled" title="Tokenize"/>
@@ -158,6 +158,12 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ee0-0t-vSs">
+                                <rect key="frame" x="190" y="210" width="160" height="51"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Set Text"/>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="627-3o-X4v"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/IntegrationTester/IntegrationTester/SplitCardElementsViewController.swift
+++ b/IntegrationTester/IntegrationTester/SplitCardElementsViewController.swift
@@ -21,6 +21,16 @@ class SplitCardElementsViewController: UIViewController {
     @IBOutlet weak var output: UITextView!
     @IBOutlet weak var cardBrand: UITextView!
     
+    @IBAction func printToConsoleLog(_ sender: Any) {
+        cardNumberTextField.text = "4242424242424242"
+        expirationDateTextField.text = "10/26"
+        cvcTextField.text = "909"
+        
+        print("cardNumberTextField.text: \(cardNumberTextField.text)")
+        print("expirationDateTextField.text: \(expirationDateTextField.text)")
+        print("cvcTextField.text: \(cvcTextField.text)")
+    }
+    
     @IBAction func tokenize(_ sender: Any) {
         let body: [String: Any] = [
             "data": [


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

-This is a PR to add UI testing to test the dynamic mask for the card number and cvc. 

It also adds a `Set Text` button, similar to the one in `TextElementUITextFieldViewController`, that adds a credit card number, expiration date, and cvc ready to be tokenized. 

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
