### PR TITLE
feat: add metadata and cardElementMetadata variables

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
@@ -9,9 +9,14 @@ import Foundation
 import Combine
 
 public protocol ElementProtocol {
-    var subject: PassthroughSubject<ElementEvent, Error> {get set}
+    var subject: PassthroughSubject<ElementEvent, Error> { get set }
+    var metadata: ElementMetadata { get }
     func setValue(elementValueReference: ElementValueReference?) -> Void
     func setValueRef(element: TextElementUITextField) -> Void
+}
+
+public protocol CardElementProtocol {
+    var cardMetadata: CardMetadata { get }
 }
 
 internal protocol InternalElementProtocol {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final public class CardNumberUITextField: TextElementUITextField, CardElementProtocol {
-    public var cardMetadata: CardMetadata = CardMetadata(cardLast4: "", cardBin: "", cardBrand: "unknown")
+    public var cardMetadata: CardMetadata = CardMetadata(cardBrand: "unknown")
     
     internal var cardBrand: CardBrandResults?
     private var cardMask: [Any]?

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
@@ -7,7 +7,9 @@
 
 import UIKit
 
-final public class CardNumberUITextField: TextElementUITextField {
+final public class CardNumberUITextField: TextElementUITextField, CardElementProtocol {
+    public var cardMetadata: CardMetadata = CardMetadata(cardLast4: "", cardBin: "", cardBrand: "unknown")
+    
     internal var cardBrand: CardBrandResults?
     private var cardMask: [Any]?
     
@@ -72,10 +74,15 @@ final public class CardNumberUITextField: TextElementUITextField {
         let complete = maskSatisfied && event.valid
         let brand = cardBrand?.bestMatchCardBrand?.cardBrandName != nil ? String(describing: cardBrand!.bestMatchCardBrand!.cardBrandName) : "unknown"
         var details = [ElementEventDetails(type: "cardBrand", message: brand)]
+        cardMetadata.cardBrand = brand
         
         if complete {
-            details.append(ElementEventDetails(type: "cardLast4", message: String(text!.suffix(4))))
-            details.append(ElementEventDetails(type: "cardBin", message: String(text!.prefix(6))))
+            var last4 = String(text!.suffix(4))
+            var bin = String(text!.prefix(6))
+            details.append(ElementEventDetails(type: "cardLast4", message: last4))
+            details.append(ElementEventDetails(type: "cardBin", message: bin))
+            cardMetadata.cardLast4 = last4
+            cardMetadata.cardBin = bin
         }
         
         let elementEvent = ElementEvent(type: "textChange", complete: complete, empty: event.empty, valid: event.valid, maskSatisfied: maskSatisfied, details: details)

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
@@ -83,6 +83,9 @@ final public class CardNumberUITextField: TextElementUITextField, CardElementPro
             details.append(ElementEventDetails(type: "cardBin", message: bin))
             cardMetadata.cardLast4 = last4
             cardMetadata.cardBin = bin
+        } else {
+            cardMetadata.cardLast4 = nil
+            cardMetadata.cardBin = nil
         }
         
         let elementEvent = ElementEvent(type: "textChange", complete: complete, empty: event.empty, valid: event.valid, maskSatisfied: maskSatisfied, details: details)

--- a/BasisTheoryElements/Sources/BasisTheoryElements/ElementMetadata.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/ElementMetadata.swift
@@ -15,7 +15,7 @@ public struct ElementMetadata {
 }
 
 public struct CardMetadata {
-    public var cardLast4: String
-    public var cardBin: String
+    public var cardLast4: String?
+    public var cardBin: String?
     public var cardBrand: String
 }

--- a/BasisTheoryElements/Sources/BasisTheoryElements/ElementMetadata.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/ElementMetadata.swift
@@ -1,0 +1,21 @@
+//
+//  ElementMetadata.swift
+//  
+//
+//  Created by Lucas Chociay on 10/01/23.
+//
+
+import Foundation
+
+public struct ElementMetadata {
+    public var complete: Bool
+    public var empty: Bool
+    public var valid: Bool
+    public var maskSatisfied: Bool
+}
+
+public struct CardMetadata {
+    public var cardLast4: String
+    public var cardBin: String
+    public var cardBrand: String
+}

--- a/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
@@ -32,6 +32,7 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
     private var cancellables = Set<AnyCancellable>()
     
     public var subject = PassthroughSubject<ElementEvent, Error>()
+    public var metadata: ElementMetadata = ElementMetadata(complete: true, empty: true, valid: true, maskSatisfied: false)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -225,6 +226,8 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
         if let getElementEvent = getElementEvent {
             elementEvent = getElementEvent(transformedTextValue, elementEvent)
         }
+        
+        self.metadata = ElementMetadata(complete: elementEvent.complete, empty: elementEvent.empty, valid: elementEvent.valid, maskSatisfied: elementEvent.maskSatisfied)
         
         // prevents sending an additional event if input didn't change
         if (previousValue == super.text) {

--- a/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
@@ -36,6 +36,11 @@ final class CardNumberUITextFieldTests: XCTestCase {
             XCTAssertEqual(brandDetails.type, "cardBrand")
             XCTAssertEqual(brandDetails.message, "visa")
             
+            // assert metadta
+            XCTAssertEqual(cardNumberTextField.metadata.empty, false)
+            XCTAssertEqual(cardNumberTextField.metadata.valid, false)
+            XCTAssertEqual(cardNumberTextField.cardMetadata.cardBrand, "visa")
+            
             if (!incompleteNumberExpectationHasBeenFulfilled) {
                 XCTAssertEqual(message.complete, false) // mask incomplete and number is invalid
                 XCTAssertEqual(eventDetails.count, 1)
@@ -74,6 +79,11 @@ final class CardNumberUITextFieldTests: XCTestCase {
             XCTAssertEqual(message.type, "textChange")
             XCTAssertEqual(message.empty, false)
             XCTAssertEqual(message.valid, true)
+            
+            // assert metadata
+            XCTAssertEqual(cardNumberTextField.metadata.empty, false)
+            XCTAssertEqual(cardNumberTextField.metadata.valid, true)
+            
             let eventDetails = message.details as [ElementEventDetails]
             let brandDetails = eventDetails[0]
             let last4Details = eventDetails[1]
@@ -88,6 +98,13 @@ final class CardNumberUITextFieldTests: XCTestCase {
                 XCTAssertEqual(brandDetails.message, "visa")
                 XCTAssertEqual(last4Details.message, "4242")
                 XCTAssertEqual(binDetails.message, "424242")
+                
+                // assert metadata
+                XCTAssertEqual(cardNumberTextField.metadata.complete, true)
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardBrand, "visa")
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardLast4, "4242")
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardBin, "424242")
+                
                 validVisaCardNumberExpectation.fulfill()
                 visaExpectationHasBeenFulfilled = true
             } else if (!mastercardExpectationHasBeenFulfilled) {
@@ -95,6 +112,12 @@ final class CardNumberUITextFieldTests: XCTestCase {
                 XCTAssertEqual(brandDetails.message, "mastercard")
                 XCTAssertEqual(last4Details.message, "5717")
                 XCTAssertEqual(binDetails.message, "545442")
+                
+                // assert metadata
+                XCTAssertEqual(cardNumberTextField.metadata.complete, true)
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardBrand, "mastercard")
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardLast4, "5717")
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardBin, "545442")
                 validMasterCardNumberExpectation.fulfill()
                 mastercardExpectationHasBeenFulfilled = true
             } else {
@@ -102,6 +125,12 @@ final class CardNumberUITextFieldTests: XCTestCase {
                 XCTAssertEqual(brandDetails.message, "americanExpress")
                 XCTAssertEqual(last4Details.message, "8868")
                 XCTAssertEqual(binDetails.message, "348570")
+                
+                // assert metadata
+                XCTAssertEqual(cardNumberTextField.metadata.complete, true)
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardBrand, "americanExpress")
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardLast4, "8868")
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardBin, "348570")
                 validAmexCardNumberExpectation.fulfill()
             }
         }.store(in: &cancellables)
@@ -129,10 +158,18 @@ final class CardNumberUITextFieldTests: XCTestCase {
             if (!message.empty) {
                 XCTAssertEqual(message.valid, true)
                 XCTAssertEqual(message.complete, true)
+                
+                // assert metadata
+                XCTAssertEqual(cardNumberTextField.metadata.valid, true)
+                XCTAssertEqual(cardNumberTextField.metadata.complete, true)
                 numberInputExpectation.fulfill()
             } else {
                 XCTAssertEqual(message.valid, false)
                 XCTAssertEqual(message.complete, false)
+                
+                // assert metadata
+                XCTAssertEqual(cardNumberTextField.metadata.valid, false)
+                XCTAssertEqual(cardNumberTextField.metadata.complete, false)
                 numberDeleteExpectation.fulfill()
             }
         }.store(in: &cancellables)

--- a/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
@@ -170,6 +170,10 @@ final class CardNumberUITextFieldTests: XCTestCase {
                 // assert metadata
                 XCTAssertEqual(cardNumberTextField.metadata.valid, false)
                 XCTAssertEqual(cardNumberTextField.metadata.complete, false)
+                
+                // card bin and last 4 should be nil for non-complete
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardLast4, nil)
+                XCTAssertEqual(cardNumberTextField.cardMetadata.cardBin, nil)
                 numberDeleteExpectation.fulfill()
             }
         }.store(in: &cancellables)

--- a/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
@@ -27,8 +27,13 @@ final class TextElementUITextFieldTests: XCTestCase {
             XCTAssertEqual(message.type, "textChange")
             XCTAssertEqual(message.complete, true)
             XCTAssertEqual(message.valid, true)
+            
+            // assert metadata updated
+            XCTAssertEqual(nameTextField.metadata.complete, message.complete)
+            XCTAssertEqual(nameTextField.metadata.valid, message.valid)
 
             if (!message.empty) {
+                XCTAssertEqual(nameTextField.metadata.empty, false)
                 nameInputExpectation.fulfill()
             } else {
                 nameDeleteExpectation.fulfill()
@@ -64,6 +69,11 @@ final class TextElementUITextFieldTests: XCTestCase {
             XCTAssertEqual(message.maskSatisfied, true)
             XCTAssertEqual(message.valid, true)
             
+            // assert metadata updated
+            XCTAssertEqual(completeField.metadata.complete, message.complete)
+            XCTAssertEqual(completeField.metadata.valid, message.valid)
+            XCTAssertEqual(completeField.metadata.maskSatisfied, message.maskSatisfied)
+            
             completeFieldExpectation.fulfill()
         }.store(in: &cancellables)
         
@@ -74,6 +84,11 @@ final class TextElementUITextFieldTests: XCTestCase {
             XCTAssertEqual(message.complete, false)
             XCTAssertEqual(message.maskSatisfied, false)
             XCTAssertEqual(message.valid, true)
+            
+            // assert metadata updated
+            XCTAssertEqual(incompleteField.metadata.complete, message.complete)
+            XCTAssertEqual(incompleteField.metadata.valid, message.valid)
+            XCTAssertEqual(incompleteField.metadata.maskSatisfied, message.maskSatisfied)
             
             incompleteFieldExpectation.fulfill()
         }.store(in: &cancellables)


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds `metadata` and `cardMetadata` variable to access event values w/o subscribing 

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
