### PR TITLE
fix: adds mask to readonly text element when using setValueRef

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
@@ -24,6 +24,7 @@ internal protocol InternalElementProtocol {
     var inputMask: [Any]? { get set }
     var getElementEvent: ((_ text: String?, _ currentElementEvent: ElementEvent) -> ElementEvent)? { get set }
     var inputTransform: ElementTransform? { get set }
+    func getMaskedValue() -> String?
 }
 
 internal protocol ElementReferenceProtocol {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
@@ -91,7 +91,7 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
         self.valueRef = element
         self.valueRef!.subject.sink { completion in } receiveValue: { message in
             if (message.type == "textChange") {
-                self.text = self.valueRef?.getValue()
+                self.text = self.valueRef?.getMaskedValue()
             }
         }.store(in: &cancellables)
     }
@@ -241,5 +241,9 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
     
     func getValue() -> String? {
         return transform(text: super.text)
+    }
+    
+    func getMaskedValue() -> String? {
+        return super.text
     }
 }

--- a/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
+++ b/IntegrationTester/AcceptanceTests/SplitCardElementsUITextFieldTests.swift
@@ -142,4 +142,14 @@ final class SplitCardElementsIntegrationTesterUITests: XCTestCase {
         
         XCTAssertEqual(cvcTextField.value as! String, "432") // mask is applied and truncates input after user action
     }
+    
+    func testMaskedElementSetValueRef() throws {
+        let cardNumberTextField = app.textFields["Card Number"]
+        let readOnlyTextField = app.textFields["Read Only"]
+        
+        cardNumberTextField.tap()
+        cardNumberTextField.typeText("4242424242")
+        
+        XCTAssertEqual(readOnlyTextField.value as! String, "4242 4242 42")
+    }
 }

--- a/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
+++ b/IntegrationTester/IntegrationTester/Base.lproj/Main.storyboard
@@ -174,6 +174,12 @@
                                     <action selector="printToConsoleLog:" destination="1yo-MQ-bQK" eventType="touchUpInside" id="83M-Z9-nEk"/>
                                 </connections>
                             </button>
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fRO-gm-zCT" customClass="TextElementUITextField" customModule="BasisTheoryElements">
+                                <rect key="frame" x="41" y="281" width="309" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="627-3o-X4v"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -185,11 +191,12 @@
                         <outlet property="cvcTextField" destination="vqA-gB-ZZB" id="q6X-4X-aam"/>
                         <outlet property="expirationDateTextField" destination="9OB-9S-4ob" id="oqo-vA-Zar"/>
                         <outlet property="output" destination="qKC-eP-oxh" id="fCS-lD-m61"/>
+                        <outlet property="readOnlyTextField" destination="fRO-gm-zCT" id="o1s-RD-bog"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WAN-47-by4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1561.5384615384614" y="-910.66350710900474"/>
+            <point key="canvasLocation" x="1561.0687022900763" y="-911.26760563380287"/>
         </scene>
     </scenes>
     <resources>

--- a/IntegrationTester/IntegrationTester/SplitCardElementsViewController.swift
+++ b/IntegrationTester/IntegrationTester/SplitCardElementsViewController.swift
@@ -15,6 +15,7 @@ class SplitCardElementsViewController: UIViewController {
     private let darkBackgroundColor : UIColor = UIColor( red: 200/255, green: 200/255, blue: 200/255, alpha: 1.0 )
     private var cancellables = Set<AnyCancellable>()
     
+    @IBOutlet weak var readOnlyTextField: TextElementUITextField!
     @IBOutlet weak var cardNumberTextField: CardNumberUITextField!
     @IBOutlet weak var expirationDateTextField: CardExpirationDateUITextField!
     @IBOutlet weak var cvcTextField: CardVerificationCodeUITextField!
@@ -62,9 +63,12 @@ class SplitCardElementsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        readOnlyTextField.setValueRef(element: cardNumberTextField)
+        
         setStyles(textField: cardNumberTextField, placeholder: "Card Number")
         setStyles(textField: expirationDateTextField, placeholder: "MM/YY")
         setStyles(textField: cvcTextField, placeholder: "CVC")
+        setStyles(textField: readOnlyTextField, placeholder: "Read Only")
         
         let cvcOptions = CardVerificationCodeOptions(cardNumberUITextField: cardNumberTextField)
         cvcTextField.setConfig(options: cvcOptions)


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- adds mask to readonly text element when using setValueRef

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
