### PR TITLE
fix: bump swift SDK version

### DIFF
--- a/BasisTheoryElements.podspec
+++ b/BasisTheoryElements.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/Basis-Theory/basistheory-ios'
   s.summary = 'BasisTheory SDK for Elements'
   s.source_files = 'BasisTheoryElements/Sources/BasisTheoryElements**/*.swift'
-  s.dependency 'BasisTheory', '0.6.0'
+  s.dependency 'BasisTheory', '0.6.1'
   s.swift_version = '5.5'
 end

--- a/BasisTheoryElements/Package.swift
+++ b/BasisTheoryElements/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-         .package(url: "https://github.com/Basis-Theory/basistheory-swift", .exact("0.6.0")),
+         .package(url: "https://github.com/Basis-Theory/basistheory-swift", .exact("0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/IntegrationTester/IntegrationTester.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IntegrationTester/IntegrationTester.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Basis-Theory/basistheory-swift",
         "state": {
           "branch": null,
-          "revision": "d66e6cbdec55fac6ded14b3771fbfd504a3679ab",
-          "version": "0.6.0"
+          "revision": "bf18937db09350893f02fd853b50ffd873dd4559",
+          "version": "0.6.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Basis-Theory/basistheory-swift",
         "state": {
           "branch": null,
-          "revision": "d66e6cbdec55fac6ded14b3771fbfd504a3679ab",
-          "version": "0.6.0"
+          "revision": "bf18937db09350893f02fd853b50ffd873dd4559",
+          "version": "0.6.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Basis-Theory/basistheory-swift",
         "state": {
           "branch": null,
-          "revision": "d4d10d63fe9373ec667a95910fbc4504b6004fde",
-          "version": "0.5.5"
+          "revision": "d66e6cbdec55fac6ded14b3771fbfd504a3679ab",
+          "version": "0.6.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-         .package(url: "https://github.com/Basis-Theory/basistheory-swift", .exact("0.6.0")),
+         .package(url: "https://github.com/Basis-Theory/basistheory-swift", .exact("0.6.1")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Bumps swift SDK version to `0.6.1` 
  - This fixes an issue where the encoding/decoding methods for `Decimal` values were overridden by the SDK

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
