### PR TITLE
feat: add focus and blur events

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
@@ -69,6 +69,8 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
     private func setup() {
         self.smartDashesType = .no
         self.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        self.addTarget(self, action: #selector(editingStarted), for: .editingDidBegin)
+        self.addTarget(self, action: #selector(editingEnded), for: .editingDidEnd)
         subject.send(ElementEvent(type: "ready", complete: true, empty: true, valid: true, maskSatisfied: false, details: []))
         TelemetryLogging.info("TextElementUITextField init", attributes: [
             "elementId": self.elementId
@@ -288,6 +290,18 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
         ])
         
         subject.send(elementEvent)
+    }
+    
+    @objc func editingStarted() {
+        let event = ElementEvent(type: "focus", complete: self.metadata.complete, empty: self.metadata.empty, valid: self.metadata.valid, maskSatisfied: self.metadata.maskSatisfied, details: [])
+        
+        subject.send(event);
+    }
+    
+    @objc func editingEnded() {
+        let event = ElementEvent(type: "blur", complete: self.metadata.complete, empty: self.metadata.empty, valid: self.metadata.valid, maskSatisfied: self.metadata.maskSatisfied, details: [])
+        
+        subject.send(event);
     }
     
     func getValue() -> String? {

--- a/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
@@ -47,6 +47,33 @@ final class TextElementUITextFieldTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
     
+    func testFocusAndBlurEvent() throws {
+        let field = TextElementUITextField()
+        
+        let focusExpectation = self.expectation(description: "Field focus")
+        let blurExpectation = self.expectation(description: "Field blur")
+        var focusExpectationFulfilled = false
+        var cancellables = Set<AnyCancellable>()
+        
+        field.subject.sink { completion in
+            print(completion)
+        } receiveValue: { message in
+            if (!focusExpectationFulfilled) {
+                XCTAssertEqual(message.type, "focus")
+                focusExpectationFulfilled = true
+                focusExpectation.fulfill()
+            } else {
+                XCTAssertEqual(message.type, "blur")
+                blurExpectation.fulfill()
+            }
+        }.store(in: &cancellables)
+        
+        field.sendActions(for: .editingDidBegin)
+        field.sendActions(for: .editingDidEnd)
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
     func testCompletionEventWithMask() throws {
         let completeField = TextElementUITextField()
         let incompleteField = TextElementUITextField()
@@ -210,4 +237,6 @@ final class TextElementUITextFieldTests: XCTestCase {
         
         XCTAssertTrue(textField.metadata.valid)
     }
+    
+    
 }


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds the `focus` and `blur` events to text field inputs

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
