### PR TITLE
fix: enableCopy on card elements

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateUITextField.swift
@@ -29,7 +29,11 @@ final public class CardExpirationDateUITextField: TextElementUITextField {
     }
     
     public override func setConfig(options: TextElementOptions?) throws {
-        throw ElementConfigError.configNotAllowed
+        if (options?.enableCopy != nil || options?.copyIconColor != nil) {
+            try! super.setConfig(options: TextElementOptions(enableCopy: options?.enableCopy, copyIconColor: options?.copyIconColor))
+        } else {
+            throw ElementConfigError.configNotAllowed
+        }
     }
     
     private func validateFutureDate(text: String) -> Bool {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardNumberElementUITextField.swift
@@ -41,7 +41,11 @@ final public class CardNumberUITextField: TextElementUITextField, CardElementPro
     }
     
     public override func setConfig(options: TextElementOptions?) throws {
-        throw ElementConfigError.configNotAllowed
+        if (options?.enableCopy != nil || options?.copyIconColor != nil) {
+            try! super.setConfig(options: TextElementOptions(enableCopy: options?.enableCopy, copyIconColor: options?.copyIconColor))
+        } else {
+            throw ElementConfigError.configNotAllowed
+        }
     }
     
     private func getDefaultCardMask() -> [Any] {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardVerificationCodeUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardVerificationCodeUITextField.swift
@@ -10,9 +10,13 @@ import Combine
 
 public struct CardVerificationCodeOptions {
     let cardNumberUITextField: CardNumberUITextField?
+    let enableCopy: Bool?
+    let copyIconColor: UIColor?
     
-    public init(cardNumberUITextField: CardNumberUITextField? = nil) {
+    public init(cardNumberUITextField: CardNumberUITextField? = nil, enableCopy: Bool? = false, copyIconColor: UIColor? = nil) {
         self.cardNumberUITextField = cardNumberUITextField
+        self.enableCopy = enableCopy
+        self.copyIconColor = copyIconColor
     }
 }
 
@@ -104,6 +108,10 @@ final public class CardVerificationCodeUITextField: TextElementUITextField {
                     self.updateCvcMask()
                 }
             }.store(in: &cancellables)
+        }
+        
+        if (options.enableCopy != nil || options.copyIconColor != nil) {
+            try! super.setConfig(options: TextElementOptions(enableCopy: options.enableCopy, copyIconColor: options.copyIconColor))
         }
     }
     

--- a/IntegrationTester/UnitTests/CardExpirationDateUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardExpirationDateUITextFieldTests.swift
@@ -308,4 +308,30 @@ final class CardExpirationDateUITextFieldTests: XCTestCase {
         
         waitForExpectations(timeout: 30, handler: nil)
     }
+    
+    func testEnableCopy() throws {
+        let expirationDateTextField = CardExpirationDateUITextField()
+        try! expirationDateTextField.setConfig(options: TextElementOptions(enableCopy: true))
+        
+        let rightViewContainer = expirationDateTextField.rightView
+        let iconImageView = rightViewContainer?.subviews.compactMap { $0 as? UIImageView }.first
+        
+        // assert icon exists
+        XCTAssertNotNil(expirationDateTextField.rightView)
+        XCTAssertNotNil(iconImageView)
+    }
+    
+    func testCopyIconColor() throws {
+        let expirationDateTextField = CardExpirationDateUITextField()
+        try! expirationDateTextField.setConfig(options: TextElementOptions(enableCopy: true, copyIconColor: UIColor.red))
+        
+        let rightViewContainer = expirationDateTextField.rightView
+        let iconImageView = rightViewContainer?.subviews.compactMap { $0 as? UIImageView }.first
+        
+        // assert icon exists
+        XCTAssertNotNil(iconImageView)
+        
+        // assert color
+        XCTAssertEqual(iconImageView?.tintColor, UIColor.red)
+    }
 }

--- a/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardNumberUITextFieldTests.swift
@@ -226,4 +226,30 @@ final class CardNumberUITextFieldTests: XCTestCase {
         waitForExpectations(timeout: 30, handler: nil)
         
     }
+    
+    func testEnableCopy() throws {
+        let cardNumberTextField = CardNumberUITextField()
+        try! cardNumberTextField.setConfig(options: TextElementOptions(enableCopy: true))
+        
+        let rightViewContainer = cardNumberTextField.rightView
+        let iconImageView = rightViewContainer?.subviews.compactMap { $0 as? UIImageView }.first
+        
+        // assert icon exists
+        XCTAssertNotNil(cardNumberTextField.rightView)
+        XCTAssertNotNil(iconImageView)
+    }
+    
+    func testCopyIconColor() throws {
+        let cardNumberTextField = CardExpirationDateUITextField()
+        try! cardNumberTextField.setConfig(options: TextElementOptions(enableCopy: true, copyIconColor: UIColor.red))
+        
+        let rightViewContainer = cardNumberTextField.rightView
+        let iconImageView = rightViewContainer?.subviews.compactMap { $0 as? UIImageView }.first
+        
+        // assert icon exists
+        XCTAssertNotNil(iconImageView)
+        
+        // assert color
+        XCTAssertEqual(iconImageView?.tintColor, UIColor.red)
+    }
 }

--- a/IntegrationTester/UnitTests/CardVerificationCodeUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardVerificationCodeUITextFieldTests.swift
@@ -155,4 +155,30 @@ final class CardVerificationCodeUITextFieldTests: XCTestCase {
         
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func testEnableCopy() throws {
+        let cvcField = CardVerificationCodeUITextField()
+        cvcField.setConfig(options: CardVerificationCodeOptions(enableCopy: true))
+        
+        let rightViewContainer = cvcField.rightView
+        let iconImageView = rightViewContainer?.subviews.compactMap { $0 as? UIImageView }.first
+        
+        // assert icon exists
+        XCTAssertNotNil(cvcField.rightView)
+        XCTAssertNotNil(iconImageView)
+    }
+    
+    func testCopyIconColor() throws {
+        let cvcField = CardVerificationCodeUITextField()
+        cvcField.setConfig(options: CardVerificationCodeOptions(enableCopy: true, copyIconColor: UIColor.red))
+        
+        let rightViewContainer = cvcField.rightView
+        let iconImageView = rightViewContainer?.subviews.compactMap { $0 as? UIImageView }.first
+        
+        // assert icon exists
+        XCTAssertNotNil(iconImageView)
+        
+        // assert color
+        XCTAssertEqual(iconImageView?.tintColor, UIColor.red)
+    }
 }


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Enables the `enableCopy` and `copyIconColor` attributes on split card elements.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
