### PR TITLE
feat: add type conversion when submitting element values

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
@@ -28,8 +28,17 @@ internal protocol InternalElementProtocol {
     func getMaskedValue() -> String?
 }
 
+public enum ElementValueType: String {
+    case int = "int"
+    case float = "float"
+    case double = "double"
+    case bool = "bool"
+    case string = "string"
+}
+
 internal protocol ElementReferenceProtocol {
     func getValue() -> String?
+    var getValueType: ElementValueType? { get set }
     var isComplete: Bool? { get set }
     var elementId: String { get set }
 }
@@ -43,11 +52,13 @@ public class ElementValueReference: ElementReferenceProtocol {
     var elementId: String
     var valueMethod: (() -> String)?
     var isComplete: Bool? = true
+    var getValueType: ElementValueType? = .string
     
-    init(elementId: String = UUID(uuid: UUID_NULL).uuidString, valueMethod: (() -> String)?, isComplete: Bool?) {
+    init(elementId: String = UUID(uuid: UUID_NULL).uuidString, valueMethod: (() -> String)?, isComplete: Bool?, getValueType: ElementValueType? = .string) {
         self.valueMethod = valueMethod
         self.isComplete = isComplete
         self.elementId = elementId
+        self.getValueType = getValueType
     }
 
     func getValue() -> String? {

--- a/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BaseElement.swift
@@ -30,7 +30,6 @@ internal protocol InternalElementProtocol {
 
 public enum ElementValueType: String {
     case int = "int"
-    case float = "float"
     case double = "double"
     case bool = "bool"
     case string = "string"

--- a/BasisTheoryElements/Sources/BasisTheoryElements/BasisTheoryElements.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BasisTheoryElements.swift
@@ -301,8 +301,6 @@ final public class BasisTheoryElements {
                     body[key] = Int(textValue!)
                 case .double:
                     body[key] = Double(textValue!)
-                case .float:
-                    body[key] = Float(textValue!)
                 case .bool:
                     body[key] = Bool(textValue!)
                 case .string:

--- a/BasisTheoryElements/Sources/BasisTheoryElements/BasisTheoryElements.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BasisTheoryElements.swift
@@ -295,8 +295,22 @@ final public class BasisTheoryElements {
                     
                     throw TokenizingError.invalidInput
                 }
-                body[key] = textValue
-                
+
+                switch (v.getValueType) {
+                case .int:
+                    body[key] = Int(textValue!)
+                case .double:
+                    body[key] = Double(textValue!)
+                case .float:
+                    body[key] = Float(textValue!)
+                case .bool:
+                    body[key] = Bool(textValue!)
+                case .string:
+                    body[key] = textValue
+                case .none:
+                    body[key] = textValue
+                }
+
                 TelemetryLogging.info("Retrieving element value for API call", attributes: [
                     "elementId": v.elementId,
                     "endpoint": endpoint,

--- a/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/CardExpirationDateUITextField.swift
@@ -67,12 +67,12 @@ final public class CardExpirationDateUITextField: TextElementUITextField {
     }
     
     public func month() -> ElementValueReference {
-        let monthReference = ElementValueReference(elementId: self.elementId, valueMethod: getMonthValue, isComplete: self.isComplete)
+        let monthReference = ElementValueReference(elementId: self.elementId, valueMethod: getMonthValue, isComplete: self.isComplete, getValueType: .int)
         return monthReference
     }
     
     public func year() -> ElementValueReference {
-        let yearReference = ElementValueReference(elementId: self.elementId, valueMethod: getYearValue, isComplete: self.isComplete)
+        let yearReference = ElementValueReference(elementId: self.elementId, valueMethod: getYearValue, isComplete: self.isComplete, getValueType: .int)
         return yearReference
     }
     

--- a/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
@@ -15,13 +15,15 @@ public struct TextElementOptions {
     let validation: NSRegularExpression?
     let enableCopy: Bool?
     let copyIconColor: UIColor?
+    let getValueType: ElementValueType?
     
-    public init(mask: [Any]? = nil, transform: ElementTransform? = nil, validation: NSRegularExpression? = nil, enableCopy: Bool? = false, copyIconColor: UIColor? = nil) {
+    public init(mask: [Any]? = nil, transform: ElementTransform? = nil, validation: NSRegularExpression? = nil, enableCopy: Bool? = false, copyIconColor: UIColor? = nil, getValueType: ElementValueType? = .string) {
         self.mask = mask
         self.transform = transform
         self.validation = validation
         self.enableCopy = enableCopy
         self.copyIconColor = copyIconColor
+        self.getValueType = getValueType
     }
 }
 
@@ -37,6 +39,7 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
     var readOnly: Bool = false
     var valueRef: TextElementUITextField?
     var copyIconColor: UIColor?
+    var getValueType: ElementValueType? = .string
     private var cancellables = Set<AnyCancellable>()
     private var copyIconImageView: UIImageView = UIImageView()
     
@@ -189,6 +192,12 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
         
         if ((options?.enableCopy) != nil && options?.enableCopy == true) {
             setupCopy()
+        }
+        
+        if (options?.getValueType != nil) {
+            self.getValueType = options?.getValueType
+        } else {
+            self.getValueType = .string
         }
     }
     

--- a/IntegrationTester/UnitTests/CardExpirationDateUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/CardExpirationDateUITextFieldTests.swift
@@ -196,8 +196,8 @@ final class CardExpirationDateUITextFieldTests: XCTestCase {
         TokensAPI.getByIdWithRequestBuilder(id: createdToken["id"] as! String).addHeader(name: "BT-API-KEY", value: privateApiKey).execute { result in
             do {
                 let token = try result.get().body.data!.value as! [String: Any]
-                XCTAssertEqual(token["monthRef"] as! String, String(self.formatMonth(month: self.getCurrentMonth())))
-                XCTAssertEqual(token["yearRef"] as! String, formattedYear)
+                XCTAssertEqual(token["monthRef"] as? Int, Int(self.formatMonth(month: self.getCurrentMonth())))
+                XCTAssertEqual(token["yearRef"] as? Int, Int(formattedYear))
                 
                 idQueryExpectation.fulfill()
             } catch {


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Adds the `getValueType` option for converting element value types before sending to API.

- ⚠️ BREAKING CHANGE: 
   - The `month` and `year` methods of `CardExpirationDateUITextField` will now send `Int` values to the API.
   - This will cause any tokenization response w/ these values to also return `Int`. 

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
