### PR TITLE
fix: trigger text change events when setting text programmatically

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/TextElementUITextField.swift
@@ -130,6 +130,8 @@ public class TextElementUITextField: UITextField, InternalElementProtocol, Eleme
             if let validation = validation {
                 self.isComplete = self.isComplete ?? true && validation(transform(text: newValue))
             }
+
+            textFieldDidChange()
         }
         get { nil }
     }

--- a/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
@@ -237,27 +237,6 @@ final class TextElementUITextFieldTests: XCTestCase {
         XCTAssertTrue(textField.metadata.valid)
     }
     
-    func testIncompleteWhenCleared() throws {
-        let textField = TextElementUITextField()
-        var cancellables = Set<AnyCancellable>()
-        
-        textField.insertText("a")
-        XCTAssertTrue(textField.metadata.complete)
-        
-        textField.text = ""
-        
-        textField.subject.sink { completion in
-            print(completion)
-        } receiveValue: { message in
-            XCTAssertEqual(message.type, "textChange")
-            XCTAssertEqual(message.complete, true)
-            XCTAssertEqual(message.maskSatisfied, true)
-            XCTAssertEqual(message.empty, true)
-        }.store(in: &cancellables)
-        
-        XCTAssertTrue(textField.metadata.empty)
-    }
-    
     func testEnableCopy() throws {
         let textField = TextElementUITextField()
         try! textField.setConfig(options: TextElementOptions(enableCopy: true))

--- a/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
@@ -18,8 +18,10 @@ final class TextElementUITextFieldTests: XCTestCase {
     func testEventsWithAndWithoutText() throws {
         let nameTextField = TextElementUITextField()
         
+        var fieldCleared = false
         let nameInputExpectation = self.expectation(description: "Name input")
         let nameDeleteExpectation = self.expectation(description: "Name delete")
+
         var cancellables = Set<AnyCancellable>()
         nameTextField.subject.sink { completion in
             print(completion)
@@ -31,16 +33,20 @@ final class TextElementUITextFieldTests: XCTestCase {
             // assert metadata updated
             XCTAssertEqual(nameTextField.metadata.complete, message.complete)
             XCTAssertEqual(nameTextField.metadata.valid, message.valid)
-
-            if (!message.empty) {
+            XCTAssertEqual(nameTextField.metadata.empty, message.empty)
+            
+            if (fieldCleared) {
+                XCTAssertEqual(message.empty, true)
+                nameDeleteExpectation.fulfill()
+                fieldCleared = false
+            } else {
                 XCTAssertEqual(nameTextField.metadata.empty, false)
                 nameInputExpectation.fulfill()
-            } else {
-                nameDeleteExpectation.fulfill()
             }
         }.store(in: &cancellables)
 
         nameTextField.insertText("Drewsue Webuino")
+        fieldCleared = true
         nameTextField.text = ""
         nameTextField.insertText("")
         
@@ -225,6 +231,9 @@ final class TextElementUITextFieldTests: XCTestCase {
         XCTAssertFalse(textField.metadata.valid)
         
         textField.text = ""
+        
+        XCTAssertTrue(textField.metadata.empty)
+        
         textField.insertText("DAFFY_DUCK500")
         
         XCTAssertTrue(textField.metadata.valid)
@@ -232,6 +241,9 @@ final class TextElementUITextFieldTests: XCTestCase {
         try! textField.setConfig(options: TextElementOptions(validation: nil))
         
         textField.text = ""
+        
+        XCTAssertTrue(textField.metadata.empty)
+
         textField.insertText("password!")
         
         XCTAssertTrue(textField.metadata.valid)

--- a/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
+++ b/IntegrationTester/UnitTests/TextElementUITextFieldTests.swift
@@ -237,6 +237,27 @@ final class TextElementUITextFieldTests: XCTestCase {
         XCTAssertTrue(textField.metadata.valid)
     }
     
+    func testIncompleteWhenCleared() throws {
+        let textField = TextElementUITextField()
+        var cancellables = Set<AnyCancellable>()
+        
+        textField.insertText("a")
+        XCTAssertTrue(textField.metadata.complete)
+        
+        textField.text = ""
+        
+        textField.subject.sink { completion in
+            print(completion)
+        } receiveValue: { message in
+            XCTAssertEqual(message.type, "textChange")
+            XCTAssertEqual(message.complete, true)
+            XCTAssertEqual(message.maskSatisfied, true)
+            XCTAssertEqual(message.empty, true)
+        }.store(in: &cancellables)
+        
+        XCTAssertTrue(textField.metadata.empty)
+    }
+    
     func testEnableCopy() throws {
         let textField = TextElementUITextField()
         try! textField.setConfig(options: TextElementOptions(enableCopy: true))


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- BREAKING CHANGE: Fix an issue where setting text programmatically on an element field `elementField.text = "<anything>"` would not trigger a text change event and not update some flags like `empty`

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
