### PR TITLE
fix: allow empty body responses from proxy

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/ProxyHelpers.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/ProxyHelpers.swift
@@ -73,7 +73,7 @@ struct ProxyHelpers {
             let shouldExposeRawProxyResponse = (response as? HTTPURLResponse)?.allHeaderFields["bt-expose-raw-proxy-response"] as? String != nil
             
             if let response = response {
-                if let data = data {
+                if let data = data, !data.isEmpty {
                     do {
                         let serializedJson = try JSONSerialization.jsonObject(with: data, options: [])
                         
@@ -99,10 +99,11 @@ struct ProxyHelpers {
                         ])
                     }
                 } else {
-                    completion(response, nil, error)
-                    TelemetryLogging.warn("Unexpected destination URL response: response does not have a body", error: error, attributes: [
+                    completion(response, JSON.dictionaryValue([:]), nil)
+                    TelemetryLogging.info("Successful API response w/ empty/nil body", attributes: [
                         "endpoint": endpoint,
                         "BT-TRACE-ID": btTraceId,
+                        "apiSuccess": true
                     ])
                 }
             } else {


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Allow empty responses from proxied URL instead of throwing

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
