### PR TITLE
fix: remove the requirement to check API key type when tokenizing

### DIFF
--- a/BasisTheoryElements/Sources/BasisTheoryElements/BasisTheoryElements.swift
+++ b/BasisTheoryElements/Sources/BasisTheoryElements/BasisTheoryElements.swift
@@ -96,17 +96,6 @@ final public class BasisTheoryElements {
             return
         }
 
-        guard (getApiKey(apiKey).contains("pub")) || (getApiKey(apiKey).contains("sess")) else {
-            completion(nil, TokenizingError.invalidApiKey)
-            TelemetryLogging.warn("Tried to tokenize with a non-public or non session key with tokenize function", attributes: [
-                "endpoint": "POST /tokenize",
-                "BT-TRACE-ID": btTraceId,
-                "apiSuccess": false
-            ])
-            
-            return
-        }
-        
         BasisTheoryAPI.basePath = basePath
         TokenizeAPI.tokenizeWithRequestBuilder(body: AnyCodable(mutableBody)).addBasisTheoryElementHeaders(apiKey: getApiKey(apiKey), btTraceId: btTraceId).execute { result in
             completeApiRequest(endpoint: endpoint, btTraceId: btTraceId, result: result, completion: completion)
@@ -126,20 +115,10 @@ final public class BasisTheoryElements {
             completion(nil, TokenizingError.invalidInput) // error logged with more detail in replaceElementRefs
             return
         }
-        
+
         mutableBody.data = mutableData
-        
-        guard (getApiKey(apiKey).contains("pub")) || (getApiKey(apiKey).contains("sess")) else {
-            completion(nil, TokenizingError.invalidApiKey)
-            TelemetryLogging.warn("Tried to tokenize with a non-public or non session key with tokenize function", attributes: [
-                "endpoint": "POST /tokens",
-                "BT-TRACE-ID": btTraceId,
-                "apiSuccess": false
-            ])
-            
-            return
-        }
-        
+
+
         BasisTheoryAPI.basePath = basePath
         let createTokenRequest = mutableBody.toCreateTokenRequest()
         

--- a/IntegrationTester/UnitTests/TokenizeAndCreateTokenServiceTests.swift
+++ b/IntegrationTester/UnitTests/TokenizeAndCreateTokenServiceTests.swift
@@ -18,7 +18,7 @@ final class TokenizeAndCreateTokenServiceTests: XCTestCase {
     
     override func tearDownWithError() throws { }
     
-    func testTokenizeChecksForApplicationTypeOfPublic() throws {
+    func testTokenizeChecksForValidApiKey() throws {
         let body: [String: Any] = [
             "myProp": "myValue"
         ]
@@ -27,7 +27,7 @@ final class TokenizeAndCreateTokenServiceTests: XCTestCase {
         let tokenizeExpectation = self.expectation(description: "Tokenize")
         BasisTheoryElements.tokenize(body: body, apiKey: privateApiKey) { data, error in
             XCTAssertNil(data)
-            XCTAssertEqual(error as! TokenizingError, TokenizingError.applicationTypeNotPublic)
+            XCTAssertEqual(error as! TokenizingError, TokenizingError.invalidApiKey)
             
             tokenizeExpectation.fulfill()
         }
@@ -51,7 +51,7 @@ final class TokenizeAndCreateTokenServiceTests: XCTestCase {
         waitForExpectations(timeout: TIMEOUT_EXPECTATION)
     }
     
-    func testCreateTokenChecksForApplicationTypeOfPublic() throws {
+    func testCreateTokenChecksForValidApiKey() throws {
         let body = CreateToken(type: "token", data: [
             "myProp": "myValue"
         ])
@@ -60,7 +60,7 @@ final class TokenizeAndCreateTokenServiceTests: XCTestCase {
         let tokenizeExpectation = self.expectation(description: "Tokenize")
         BasisTheoryElements.createToken(body: body, apiKey: privateApiKey) { data, error in
             XCTAssertNil(data)
-            XCTAssertEqual(error as! TokenizingError, TokenizingError.applicationTypeNotPublic)
+            XCTAssertEqual(error as! TokenizingError, TokenizingError.invalidApiKey)
             
             tokenizeExpectation.fulfill()
         }

--- a/IntegrationTester/UnitTests/TokenizeAndCreateTokenServiceTests.swift
+++ b/IntegrationTester/UnitTests/TokenizeAndCreateTokenServiceTests.swift
@@ -17,24 +17,7 @@ final class TokenizeAndCreateTokenServiceTests: XCTestCase {
     }
     
     override func tearDownWithError() throws { }
-    
-    func testTokenizeChecksForValidApiKey() throws {
-        let body: [String: Any] = [
-            "myProp": "myValue"
-        ]
-        
-        let privateApiKey = Configuration.getConfiguration().privateBtApiKey!
-        let tokenizeExpectation = self.expectation(description: "Tokenize")
-        BasisTheoryElements.tokenize(body: body, apiKey: privateApiKey) { data, error in
-            XCTAssertNil(data)
-            XCTAssertEqual(error as! TokenizingError, TokenizingError.invalidApiKey)
-            
-            tokenizeExpectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: TIMEOUT_EXPECTATION)
-    }
-    
+ 
     func testTokenizeReturnsErrorFromApplicationCheck() throws {
         let body: [String: Any] = [
             "myProp": "myValue"
@@ -50,24 +33,7 @@ final class TokenizeAndCreateTokenServiceTests: XCTestCase {
         
         waitForExpectations(timeout: TIMEOUT_EXPECTATION)
     }
-    
-    func testCreateTokenChecksForValidApiKey() throws {
-        let body = CreateToken(type: "token", data: [
-            "myProp": "myValue"
-        ])
-        
-        let privateApiKey = Configuration.getConfiguration().privateBtApiKey!
-        let tokenizeExpectation = self.expectation(description: "Tokenize")
-        BasisTheoryElements.createToken(body: body, apiKey: privateApiKey) { data, error in
-            XCTAssertNil(data)
-            XCTAssertEqual(error as! TokenizingError, TokenizingError.invalidApiKey)
-            
-            tokenizeExpectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: TIMEOUT_EXPECTATION)
-    }
-    
+
     func testCreateReturnsErrorFromApplicationCheck() throws {
         let body = CreateToken(type: "token", data: [
             "myProp": "myValue"


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Remove the requirement to check API key type when tokenizing

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
